### PR TITLE
Update measurements

### DIFF
--- a/_documentation/product-import-export-format.md
+++ b/_documentation/product-import-export-format.md
@@ -109,16 +109,16 @@ dimension_units
 : (string) The units utilized by the supplier for dimensions ('cm', 'm', 'in', and 'ft' are potential options, where 'cm' is the default)
 
 weight
-: (float) Weight - default in grams (g)
+: (float) Weight in weight_units - default in grams (g)
 
 length
-: (float) Length - default in centimeters (cm)
+: (float) Length in dimension_units - default in centimeters (cm)
 
 width
-: (float) Width - default in centimeters (cm)
+: (float) Width in dimension_units - default in centimeters (cm)
 
 height
-: (float) Height - default in centimeters (cm)
+: (float) Height in dimension_units - default in centimeters (cm)
 
 #### Package Measurements
 
@@ -129,16 +129,16 @@ package_dimension_units
 : (string) The units utilized by the supplier for dimensions ('cm', 'm', 'in', and 'ft' are potential options, where 'cm' is the default)
 
 package_weight
-: (float) Package Weight - default in grams (g)
+: (float) Package Weight in package_weight_units - default in grams (g)
 
 package_length
-: (float) Package Length - default in centimeters (cm)
+: (float) Package Length in package_dimension_units - default in centimeters (cm)
 
 package_width
-: (float) Package Width - default in centimeters (cm)
+: (float) Package Width in package_dimension_units - default in centimeters (cm)
 
 package_height
-: (float) Package Height - default in centimeters (cm)
+: (float) Package Height in package_dimension_units - default in centimeters (cm)
 
 #### Identifiers
 

--- a/_documentation/product-import-export-format.md
+++ b/_documentation/product-import-export-format.md
@@ -109,16 +109,16 @@ dimension_units
 : (string) The units utilized by the supplier for dimensions ('cm', 'm', 'in', and 'ft' are potential options, where 'cm' is the default)
 
 weight
-: (float) Weight in grams (g)
+: (float) Weight (default grams)
 
 length
-: (float) Length in centimeters (cm)
+: (float) Length (default centimeters)
 
 width
-: (float) Width in centimeters (cm)
+: (float) Width (default centimeters)
 
 height
-: (float) Height in centimeters (cm)
+: (float) Height (default centimeters)
 
 #### Package Measurements
 
@@ -129,16 +129,16 @@ package_dimension_units
 : (string) The units utilized by the supplier for dimensions ('cm', 'm', 'in', and 'ft' are potential options, where 'cm' is the default)
 
 package_weight
-: (float) Package weight in grams (g)
+: (float) Package weight (default grams)
 
 package_length
-: (float) Package Length in centimeters (cm)
+: (float) Package Length (default centimeters)
 
 package_width
-: (float) Package width in centimeters (cm)
+: (float) Package width (default centimeters)
 
 package_height
-: (float) Package height in centimeters (cm)
+: (float) Package height (default centimeters)
 
 #### Identifiers
 

--- a/_documentation/product-import-export-format.md
+++ b/_documentation/product-import-export-format.md
@@ -109,16 +109,16 @@ dimension_units
 : (string) The units utilized by the supplier for dimensions ('cm', 'm', 'in', and 'ft' are potential options, where 'cm' is the default)
 
 weight
-: (float) Weight (default grams)
+: (float) Weight - default in grams (g)
 
 length
-: (float) Length (default centimeters)
+: (float) Length - default in centimeters (cm)
 
 width
-: (float) Width (default centimeters)
+: (float) Width - default in centimeters (cm)
 
 height
-: (float) Height (default centimeters)
+: (float) Height - default in centimeters (cm)
 
 #### Package Measurements
 
@@ -129,16 +129,16 @@ package_dimension_units
 : (string) The units utilized by the supplier for dimensions ('cm', 'm', 'in', and 'ft' are potential options, where 'cm' is the default)
 
 package_weight
-: (float) Package weight (default grams)
+: (float) Package weight - default in grams (g)
 
 package_length
-: (float) Package Length (default centimeters)
+: (float) Package Length - default in centimeters (cm)
 
 package_width
-: (float) Package width (default centimeters)
+: (float) Package width - default in centimeters (cm)
 
 package_height
-: (float) Package height (default centimeters)
+: (float) Package height - default in centimeters (cm)
 
 #### Identifiers
 

--- a/_documentation/product-import-export-format.md
+++ b/_documentation/product-import-export-format.md
@@ -129,16 +129,16 @@ package_dimension_units
 : (string) The units utilized by the supplier for dimensions ('cm', 'm', 'in', and 'ft' are potential options, where 'cm' is the default)
 
 package_weight
-: (float) Package weight - default in grams (g)
+: (float) Package Weight - default in grams (g)
 
 package_length
 : (float) Package Length - default in centimeters (cm)
 
 package_width
-: (float) Package width - default in centimeters (cm)
+: (float) Package Width - default in centimeters (cm)
 
 package_height
-: (float) Package height - default in centimeters (cm)
+: (float) Package Height - default in centimeters (cm)
 
 #### Identifiers
 


### PR DESCRIPTION
Clarify the measurements in the Product Import/Export CSV Format doc

Changes the verbiage for the measurements to be more specific on the units (e.g. default grams, default centimeters)