### PR TITLE
Mark Fields As Required

### DIFF
--- a/_documentation/product-import-export-format.md
+++ b/_documentation/product-import-export-format.md
@@ -184,14 +184,14 @@ sku_nondistinguishing_attribute.[N].type
 
 #### Pricing
 
-pricing.[N].catalog NAME
-: (string) [**SUPPLIER-ONLY**] Catalog Name
+pricing.[N].catalog
+: (string) [**SUPPLIER-ONLY**  REQUIRED] Catalog Name
 
 pricing.[N].minimum_tier_quantity
-: (int) Minimum Tier Quantity
+: (int) [REQUIRED] Minimum Tier Quantity
 
 pricing.[N].cost
-: (float) Cost
+: (float) [REQUIRED] Cost
 
 pricing.[N].shipping_cost
 : (float) Shipping Cost


### PR DESCRIPTION
Marks the following Pricing Fields as required for Product Import/Export CSV File Format

- pricing.[n].catalog
- pricing.[n].cost
- pricing.[n].minimum_tier_quantity

fixes #171 